### PR TITLE
Normalize sensor IDs and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,15 @@ temp_sensor = TemperatureSensor(location="Melbourne")
 pressure_sensor = PressureSensor(location="Melbourne", altitude=31)
 humidity_sensor = HumiditySensor(location="Melbourne", location_type="urban")
 
+# Activate sensors before reading
+for sensor in (temp_sensor, pressure_sensor, humidity_sensor):
+    sensor.activate()
+
 # Generate readings
 timestamp = datetime.now()
-temp_reading = temp_sensor.generate_reading(timestamp)
-pressure_reading = pressure_sensor.generate_reading(timestamp)
-humidity_reading = humidity_sensor.generate_reading(timestamp)
+temp_reading = temp_sensor.read(timestamp)
+pressure_reading = pressure_sensor.read(timestamp)
+humidity_reading = humidity_sensor.read(timestamp)
 
 print(f"T:{temp_reading.value:.1f}°C P:{pressure_reading.value:.1f}hPa H:{humidity_reading.value:.1f}%RH")
 ```

--- a/demo.py
+++ b/demo.py
@@ -30,8 +30,9 @@ def main():
     print("🚀 SENSOR SIMULATION & ANOMALY DETECTION SYSTEM DEMO")
     print("=" * 60)
     
-    # Change to the correct directory
-    os.chdir("/Users/grigorcrandon/sensor-sim")
+    # Change to repository root regardless of invocation location
+    repo_root = os.path.dirname(os.path.abspath(__file__))
+    os.chdir(repo_root)
     
     # Clean up any existing files
     if os.path.exists("data/readings.ndjson"):

--- a/src/data/generator.py
+++ b/src/data/generator.py
@@ -43,20 +43,23 @@ class DataGenerator:
         """
         self.config = network_config or SensorNetwork()
         
+        # Normalise location for sensor IDs (e.g., "Alice Springs" -> "alice_springs")
+        location_slug = self.config.location.lower().replace(" ", "_")
+
         # Create coordinated sensors
         self.temperature_sensor = TemperatureSensor(
             location=self.config.location,
-            sensor_id=f"temp_{self.config.location.lower()}"
+            sensor_id=f"temp_{location_slug}"
         )
-        
+
         self.pressure_sensor = PressureSensor(
             altitude=self.config.altitude,
-            sensor_id=f"pressure_{self.config.location.lower()}"
+            sensor_id=f"pressure_{location_slug}"
         )
-        
+
         self.humidity_sensor = HumiditySensor(
             location_type=self.config.location_type,
-            sensor_id=f"humidity_{self.config.location.lower()}"
+            sensor_id=f"humidity_{location_slug}"
         )
         
         # Activate all sensors

--- a/test_calibration.py
+++ b/test_calibration.py
@@ -1,0 +1,36 @@
+"""Tests for sensor calibration behaviour."""
+
+from datetime import datetime, timedelta
+
+from src.sensors.base_sensor import BaseSensor
+
+
+class DummySensor(BaseSensor):
+    """Simple sensor returning a constant base value for testing."""
+
+    def _generate_base_value(self, timestamp: datetime) -> float:  # pragma: no cover - behaviour trivial
+        return 50.0
+
+
+def test_calibration_corrects_reading_and_preserves_drift():
+    sensor = DummySensor(range_min=0, range_max=100)
+    sensor.set_noise_level(0)
+    sensor.set_drift_factor(0.5)  # 0.5% of range per day -> 0.5 units/day
+    sensor.activate()
+
+    # Simulate passage of time to accumulate drift
+    sensor.calibration_date = datetime.now() - timedelta(days=10)
+    reading = sensor.read(datetime.now())
+    assert abs(reading.value - 55.0) < 1e-6  # base 50 + 5 units drift
+
+    # Calibrate using a known reference value
+    sensor.calibrate(reference_value=50.0, actual_value=reading.value)
+
+    # Immediate reading should match the reference value
+    corrected = sensor.read(datetime.now())
+    assert abs(corrected.value - 50.0) < 1e-6
+
+    # Future reading shows normal drift rate from calibration time
+    future = sensor.read(datetime.now() + timedelta(days=2))
+    assert abs(future.value - 51.0) < 1e-6
+

--- a/test_sensor_ids.py
+++ b/test_sensor_ids.py
@@ -1,0 +1,10 @@
+from src.data.generator import DataGenerator, SensorNetwork
+
+
+def test_sensor_ids_normalized():
+    network = SensorNetwork(location="Alice Springs")
+    generator = DataGenerator(network)
+
+    assert generator.temperature_sensor.sensor_id == "temp_alice_springs"
+    assert generator.pressure_sensor.sensor_id == "pressure_alice_springs"
+    assert generator.humidity_sensor.sensor_id == "humidity_alice_springs"


### PR DESCRIPTION
## Summary
- sanitize location names when generating sensor IDs to avoid spaces
- activate sensors in README example and use repository root in demo script
- add regression test for normalized sensor IDs

## Testing
- `pytest -q`
- `python demo.py`

------
https://chatgpt.com/codex/tasks/task_e_68a09208ea10832bb20118ef53fe21d8